### PR TITLE
Add link to doxygen pages

### DIFF
--- a/index.md
+++ b/index.md
@@ -40,6 +40,10 @@ See below for helpful links:
 
 * [sbndaq-xporter](https://github.com/SBNSoftware/sbndaq-xporter): Code for online SBN data management
 
+
+## Documentation ###
+* [doxygen](doxygen): Auto-generated from the source code, updated nightly
+
 ## Operations ##
 * [ICARUS Operations](Operations/SBN_FD/index)
 


### PR DESCRIPTION
Depends on https://github.com/SBNSoftware/SBNSoftware.github.io/pull/11 (the page this links to won't exist until that is merged)